### PR TITLE
fix: remove unnecessary backticks from RPG documentation

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa1eec891ed731db227a36.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-basic-javascript-by-building-a-role-playing-game/62aa1eec891ed731db227a36.md
@@ -9,7 +9,7 @@ dashedName: step-149
 
 If you play the game in its current state you might notice a bug. If your `xp` is high enough, the `getMonsterAttackValue` function will return a negative number, which will actually add to your total health when fighting a monster! You can fix this issue by using a <dfn>ternary operator</dfn> to ensure negative values are not returned.
 
-The `ternary operator` is a conditional operator and can be used as a one-line `if-else` statement. The syntax is: `condition ? expressionIfTrue : expressionIfFalse`.
+The ternary operator is a conditional operator and can be used as a one-line `if-else` statement. The syntax is: `condition ? expressionIfTrue : expressionIfFalse`.
 
 Here is an example of returning a value using an `if-else` statement and a refactored example using a ternary operator:
 


### PR DESCRIPTION

Checklist:


- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.


Closes #55974

Resolved issue #55974 by removing unnecessary backticks from the RPG documentation. The backticks around non-code terms were causing formatting inconsistencies. Removed backticks around "ternary operator" and "if-else" to improve readability.
